### PR TITLE
Fix splitcontainer content overflow

### DIFF
--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -178,6 +178,7 @@ const Header = styled('h3')`
 const SplitContainer = styled(Panel)`
   display: flex;
   justify-content: center;
+  overflow: hidden;
 `;
 
 const ModuleInfo = styled('div')`

--- a/static/app/views/insights/mobile/appStarts/components/samples.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/samples.tsx
@@ -110,6 +110,7 @@ const EventSplitContainer = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: ${space(1.5)};
+  overflow: hidden;
 `;
 
 const Controls = styled('div')`

--- a/static/app/views/insights/mobile/common/components/tables/samplesTables.tsx
+++ b/static/app/views/insights/mobile/common/components/tables/samplesTables.tsx
@@ -125,6 +125,7 @@ const EventSplitContainer = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: ${space(1.5)};
+  overflow: hidden;
 `;
 
 const Controls = styled('div')`


### PR DESCRIPTION
Adds `overflow: hidden` to `SplitContainer` and `EventSplitContainer` components to prevent content from overflowing their boundaries. This addresses UI issues where content was spilling out of these flex and grid-based containers.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f7261df-c162-43f3-a4c5-f118f1ef2eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f7261df-c162-43f3-a4c5-f118f1ef2eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

